### PR TITLE
adds J character in alpha_num_keys for 1.10.py

### DIFF
--- a/Chapter 01/1.10.py
+++ b/Chapter 01/1.10.py
@@ -34,7 +34,7 @@ entry.bind("<Button-2>", show_event_details) # right mouse click
 entry.bind("<FocusIn>", show_event_details)
 
 #binding entry widget alphabets and numbers from keyboard
-alpha_num_keys = 'ABCDEFGHIGKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789'
+alpha_num_keys = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789'
 for key in alpha_num_keys:
     entry.bind("<KeyPress-%s>"%key, show_event_details)
 

--- a/Chapter 02/2.05.py
+++ b/Chapter 02/2.05.py
@@ -11,7 +11,7 @@ implementation of:
 """
 
 from tkinter import Tk, PhotoImage, Menu, Frame, Text, Scrollbar, IntVar, \
-    StringVar
+    StringVar, Toplevel, Label, Entry, Checkbutton, Button, END
 
 PROGRAM_NAME = "Footprint Editor"
 


### PR DESCRIPTION
The alpha_num_keys variable in 1.10.py lists the
entire alphabet, but is missing the J character
and has a duplicate G character. This change
converts the second G to a J.